### PR TITLE
Add ReactApp project

### DIFF
--- a/ReactApp/App.jsx
+++ b/ReactApp/App.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class App extends React.Component {
+   render() {
+      return (
+         <div>
+            Hello World changed again!!!
+         </div>
+      );
+   }
+}
+
+export default App;

--- a/ReactApp/Button.jsx
+++ b/ReactApp/Button.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+class Button extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { counter: 3 };
+        // This binding is necessary to make `this` work in the callback
+        this.handleClick = this.handleClick.bind(this);
+
+    }
+
+   handleClick () {
+       this.setState({
+           counter: this.state.counter + 1
+       })
+   };
+
+    render () {
+        return (
+            <button onClick={this.handleClick}>
+                {this.state.counter}
+            </button>
+        );
+    }
+}
+
+export default Button;

--- a/ReactApp/index.html
+++ b/ReactApp/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang = "en">
+
+   <head>
+      <meta charset = "UTF-8">
+      <title>React App</title>
+   </head>
+
+   <body>
+      <div id = "app"></div>
+      <div id = "button"></div>
+      <script src = "index.js"></script>
+   </body>
+
+</html>

--- a/ReactApp/main.js
+++ b/ReactApp/main.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App.jsx';
+import Button from './Button.jsx'
+
+ReactDOM.render(<App />, document.getElementById('app'));
+ReactDOM.render(<Button />, document.getElementById('button'));

--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ReactApp",
+  "version": "1.0.0",
+  "description": "React Application",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --hot"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "webpack": "^3.5.6",
+    "webpack-dev-server": "^2.7.1"
+  }
+}

--- a/ReactApp/webpack.config.js
+++ b/ReactApp/webpack.config.js
@@ -1,0 +1,29 @@
+var config = {
+    entry: './main.js',
+     
+    output: {
+       path:'/',
+       filename: 'index.js',
+    },
+     
+    devServer: {
+       inline: true,
+       port: 8080
+    },
+     
+    module: {
+       loaders: [
+          {
+             test: /\.jsx?$/,
+             exclude: /node_modules/,
+             loader: 'babel-loader',
+                 
+             query: {
+                presets: ['es2015', 'react']
+             }
+          }
+       ]
+    }
+ }
+ 
+ module.exports = config;


### PR DESCRIPTION
## Description
Add the ReactApp project. This project serves as a testing space to learn ReacJS. Node is required to serve up the javascript.

The project has the following dependencies defined:
- react
- react-dom
- webpack
- webpack-dev-server

Babel should be installed to compile the JS scripts.

This [tutorial](https://www.tutorialspoint.com/reactjs/reactjs_environment_setup.htm) was used to bootstrap the project.

